### PR TITLE
remove search and update system prompt to return to basic orchestrati…

### DIFF
--- a/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
+++ b/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
@@ -31,24 +31,24 @@ public static partial class Endpoints
 
     private static async Task<IResult> PostConversationAsync(
         [FromServices] ChatCompletionService chat,
-        [FromServices] AzureSearchService search,
+        //[FromServices] AzureSearchService search,
         [FromBody] ConversationRequest history)
     {
         // filter out any existing tool messages (search results)
-        history.Messages = history.Messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
+        // history.Messages = history.Messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
         // do the search here
-        var searchResults = await search.QueryDocumentsAsync(history.Messages[^1].Content);
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-        var toolMsg = new Message
-        {
-            Id = Guid.NewGuid().ToString(),
-            Role = AuthorRole.Tool.ToString().ToLower(),
-            Date = DateTime.UtcNow,
-            Content = JsonSerializer.Serialize<ToolContentResponse>(searchResults, options)
-        };
-        // add search results to the conversation
-        history.Messages.Add(toolMsg);
-        
+        //var searchResults = await search.QueryDocumentsAsync(history.Messages[^1].Content);
+        //var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        //var toolMsg = new Message
+        //{
+        //    Id = Guid.NewGuid().ToString(),
+        //    Role = AuthorRole.Tool.ToString().ToLower(),
+        //    Date = DateTime.UtcNow,
+        //    Content = JsonSerializer.Serialize<ToolContentResponse>(searchResults, options)
+        //};
+        //// add search results to the conversation
+        //history.Messages.Add(toolMsg);
+
         // return result from LLM
         return Results.Ok(await chat.CompleteChat([.. history.Messages]));
     }

--- a/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
+++ b/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
@@ -67,7 +67,7 @@ public class ChatCompletionService
 
         _promptDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Plugins");
 
-        builder.Plugins.AddFromPromptDirectory(_promptDirectory);
+        //builder.Plugins.AddFromPromptDirectory(_promptDirectory);
 
         _kernel = builder.Build();
     }
@@ -87,39 +87,26 @@ public class ChatCompletionService
 
     public async Task<ChatCompletion> CompleteChat(Message[] messages)
     {
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-        string documentContents = string.Empty;
-        if (messages.Any(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)))
-        {
-            // parse out the document contents
-            var toolContent = JsonSerializer.Deserialize<ToolContentResponse>(
-                messages.First(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).Content, options);
-            documentContents = string.Join("\r", toolContent.Citations.Select(c => $"{c.Title}:{c.Content}:{c.AdditionalContent}"));
-        }
-        else
-        {
-            documentContents = "no source available.";
-        }
+        //var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        //string documentContents = string.Empty;
+        //if (messages.Any(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)))
+        //{
+        //    // parse out the document contents
+        //    var toolContent = JsonSerializer.Deserialize<ToolContentResponse>(
+        //        messages.First(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).Content, options);
+        //    documentContents = string.Join("\r", toolContent.Citations.Select(c => $"{c.Title}:{c.Content}:{c.AdditionalContent}"));
+        //}
+        //else
+        //{
+        //    documentContents = "no source available.";
+        //}
 
         var sysmessage = $$$"""
-                ## Notes ##
-                {{{documentContents}}}
-                ## End Notes ##
-                You are an agent helping to analyze the provided medical notes about patient interactions, and supplement with additional data using plugin functions available to you. 
-                Respond with a count of notes used to the question and the list of note data in a table formatted like the sample answer.
-                Include data in the table asked for by the user, only if you can explicitly find it in the note or data retrieved using plugin functions available. 
-                If you do not have data available to meet the user's request, include only what you have, with "not found" listed for missing data. Never make up data.
-                If the data set is large, display max 10 indicating it is just a sample. 
-                Include source citations, which must be in the format [doc1], [doc2], etc.
-                Sample Answer:
-                (2) notes found:\n
-                Patient Name	|	MRN	    | Citation |\n
-                John Johnson 	|	1234567 | [doc1]   |\n
-                Peter Peterson	| 	7654321 | [doc2]   |
+                You are an a helpful agent answering questions based on information available to you, general information and functions.
                 """;
         var history = new ChatHistory(sysmessage);
 
-        // filter out 'tool' messages
+        //filter out 'tool' messages and add rest to history
         messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase))
             .ToList()
             .ForEach(m => history.AddUserMessage(m.Content));


### PR DESCRIPTION
This pull request includes changes that appear to comment out certain functionalities in the `ChatApp.Server` project. The most notable changes include the removal of AzureSearchService usage from the `PostConversationAsync` method, the removal of the plugin addition from the `ChatCompletionService` constructor, and the simplification of the `CompleteChat` method.

Changes in `src/ChatApp/ChatApp.Server/Endpoints.Api.cs`:

* [`public static WebApplication MapApiEndpoints(this WebApplication app)`](diffhunk://#diff-6cdaa69085f8d0cd0db2369667e1d218e2da51da0c61e6c81cd7bea2e996f902L34-R50): The AzureSearchService usage has been commented out in the `PostConversationAsync` method. This includes the removal of the search query and the creation of a tool message based on the search results. The history messages are no longer being filtered for tool messages.

Changes in `src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs`:

* `public ChatCompletionService(IOptions<OpenAIOptions> options, IOptions<AzureAdOp`: The addition of plugins from the prompt directory has been commented out in the constructor of `ChatCompletionService`.
* [`public async Task<ChatCompletion> CompleteChat(string prompt)`](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfL90-R109): The `CompleteChat` method has been simplified. The extraction of document contents from tool messages has been commented out. The system message has been simplified and no longer includes notes and a sample answer. The filtering of 'tool' messages from the history has been retained.